### PR TITLE
Fixes "Assertion '__pos <= size()" on Fedora

### DIFF
--- a/makefile
+++ b/makefile
@@ -79,7 +79,7 @@ COVERAGE_DIR=cov
 # --- COMPILATION FLAGS: Things you may want/need to configure, but I've put
 # them at sane defaults.
 CC=g++
-FLAGS=-Wall -Wextra -pedantic
+FLAGS=-Wall -Wextra -pedantic -O2
 INC=-I$(INCLUDE_DIR) -I$(SOURCE_DIR) $(addprefix -I,$(EXTRA_INCLUDES))
 CFLAGS=$(FLAGS) -std=c++03  -fPIC $(INC) -c
 LFLAGS=$(FLAGS)


### PR DESCRIPTION
This fixes issue #8.

I'm not completely sure why this fixes it, but it works fine on Fedora 29 with GCC 8.2.1 now. 