### PR TITLE
Stdin

### DIFF
--- a/src/astyle_main.cpp
+++ b/src/astyle_main.cpp
@@ -668,6 +668,7 @@ int main(int argc, char *argv[])
             if (!ok)
             {
                 printHelpSimple();
+                exit(1);
             }
         }
     }

--- a/src/astyle_main.cpp
+++ b/src/astyle_main.cpp
@@ -355,7 +355,7 @@ bool parseOptions(ASFormatter &formatter,
     return ok;
 }
 
-void printHelpTitle()
+void printTitle()
 {
     cout << endl;
 
@@ -372,7 +372,7 @@ void printHelpTitle()
 }
 void printHelpSimple(int isGetchar=0)
 {
-
+    printTitle();
     SetColor(14,0);
     cout << endl;
     cout << "Usage  :  iStyle [options] Foo.v  B*r.v  [...]\n";
@@ -394,7 +394,7 @@ void printHelpSimple(int isGetchar=0)
 
 void printHelpFull()
 {
-
+    printTitle();
     SetColor(14,0);
     cout << endl;
     cout << "Usage  :  iStyle [options] Foo.v  B*r.v  [...]\n";
@@ -595,8 +595,6 @@ int main(int argc, char *argv[])
     _err = &cerr;
     _suffix = ".orig";
 
-    printHelpTitle();
-
     // manage flags
     for (int i=1; i<argc; i++)
     {
@@ -699,6 +697,8 @@ int main(int argc, char *argv[])
     }
     else
     {
+        printTitle();
+
         // indent the given files
         for (int i=0; i<fileNameVector.size(); i++)
         {


### PR DESCRIPTION
Spoke too soon in PR #12. Despite having `help` in its name, `printHelpTitle()` actually prints the program's title even when help messages are not displayed. Since the title is printed to stdout it would get mixed up with code that is also written there from stdin.

Fix by changing the name of `printHelpTitle()` to the more obvious `printTitle()`, and by only calling it when formatting a list of one or more named files (in which case no code is written to stdout so it doesn't hurt to write the title there). In the case of stdin->stdout, no title is printed (as is customary for that use case).

Also, the first commit fixes something that is almost certainly a bug (missing exit() call).