### PR TITLE
repiar empty buffer error in MSVC

### DIFF
--- a/src/astyle/ASStreamIterator.cpp
+++ b/src/astyle/ASStreamIterator.cpp
@@ -77,7 +77,7 @@ string ASStreamIterator::nextLine()
         str = "Could not read line " ;
         error(str.c_str(), "(too long?)");
     }
-    if (buffer[buffer.size() - 1] == '\r')
+    if (!buffer.empty() && buffer[buffer.size() - 1] == '\r')
     {
         buffer.erase(buffer.size() - 1);
     }


### PR DESCRIPTION
when compiled with MSVC, buffer in ASStreamIterator.cpp can be returned empty, in this case, `buffer.size() - 1 = -1`, which will cause `buffer[buffer.size() - 1]` crash.

`!buffer.empty()` will handle this issue.