### PR TITLE
Add +: and -: to operator group

### DIFF
--- a/src/astyle.h
+++ b/src/astyle.h
@@ -94,7 +94,7 @@ class ASResource
         static const string AS_LS_ASSIGN, AS_EQUAL_EQUAL, AS_NOT_EQUAL_EQUAL;
         static const string AS_BITNOT_AND, AS_BITNOT_OR, AS_BITNOT_XNOR, AS_NOT_XNOR;
 
-        static const string AS_EQUAL, AS_NOT_EQUAL, AS_GR_EQUAL, AS_GR_GR;
+        static const string AS_EQUAL, AS_NOT_EQUAL, AS_GR_EQUAL, AS_GR_GR, AS_INDEX_ADD, AS_INDEX_MINUS;
         static const string AS_LS_EQUAL, AS_LS_LS, AS_AND, AS_OR;
         static const string AS_PAREN_PAREN, AS_BLPAREN_BLPAREN;
         static const string AS_PLUS, AS_MINUS, AS_MULT, AS_EXP, AS_DIV, AS_MOD, AS_GR, AS_LS;

--- a/src/astyle/ASFormatter.cpp
+++ b/src/astyle/ASFormatter.cpp
@@ -154,6 +154,8 @@ void ASFormatter::staticInit()
     operators.push_back(&AS_EQUAL);
     operators.push_back(&AS_NOT_EQUAL);
     operators.push_back(&AS_GR_EQUAL);
+    operators.push_back(&AS_INDEX_ADD);
+    operators.push_back(&AS_INDEX_MINUS);
 
     operators.push_back(&AS_GR_GR);
     operators.push_back(&AS_LS_EQUAL);

--- a/src/astyle/ASResource.cpp
+++ b/src/astyle/ASResource.cpp
@@ -105,6 +105,8 @@ const string ASResource::AS_GR_EQUAL = string(">=");
 const string ASResource::AS_GR_GR = string(">>");
 const string ASResource::AS_LS_EQUAL = string("<=");
 const string ASResource::AS_LS_LS = string("<<");
+const string ASResource::AS_INDEX_ADD = string("+:");
+const string ASResource::AS_INDEX_MINUS = string("-:");
 
 const string ASResource::AS_AND = string("&&");
 const string ASResource::AS_OR = string("||");


### PR DESCRIPTION
add partial selection operator "+:" and "-:" to operator group, or modelsim will generate warnings for them.